### PR TITLE
ci: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/askpt/code-metrics/security/code-scanning/1](https://github.com/askpt/code-metrics/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow to restrict the `GITHUB_TOKEN` privileges. The principle of least privilege suggests setting `contents: read`, which allows reading repository contents but prevents write actions, such as pushing commits or creating releases. Since the job only checks out code and runs tests, this level of access is sufficient. The `permissions` block should be placed at the top level (so it applies to all jobs), e.g., right after the `name` declaration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
