### PR TITLE
fix: upgrade engines.vscode to ^1.106.0 to match @types/vscode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/sponsors/askpt"
   },
   "engines": {
-    "vscode": "^1.103.0"
+    "vscode": "^1.106.0"
   },
   "keywords": [
     "complexity",


### PR DESCRIPTION
Fixes the build error where @types/vscode ^1.106.1 was greater than engines.vscode ^1.103.0.

This PR upgrades engines.vscode to ^1.106.0 to resolve the version mismatch and allow the build to pass.