### PR TITLE
ci: pin codecov action to SHA and add timeout to PR title validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         if: runner.os != 'Linux'
       - name: Upload coverage to Codecov
         if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           directory: ./coverage
           fail_ci_if_error: false

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -11,6 +11,7 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
- Pin codecov/codecov-action from floating @v5 tag to commit SHA
  671740ac38dd9b0130fbe1cec585b89eea48d3de (v5.5.2) for supply chain security
- Add timeout-minutes: 5 to validate_pr_title job to prevent stuck runs

Closes #188

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
