### PR TITLE
ci: remove dead OS conditional in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Test
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            xvfb-run -a npm test
-          else
-            npm test
-          fi
+        run: xvfb-run -a npm test
       - name: Publish
         if: success()
         run: npm run deploy


### PR DESCRIPTION
The release job always runs on ubuntu-latest, making the
if RUNNER_OS = Linux conditional always true and the else
branch permanently unreachable. Simplify to a single
unconditional xvfb-run call.

Closes #195
Closes #196
Closes #197

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
