### PR TITLE
ci: add concurrency group to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+# Serialize release runs so rapid pushes to main don't create parallel
+# release-please executions that could conflict over manifest state.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     timeout-minutes: 5


### PR DESCRIPTION
Prevent parallel release-please executions when multiple commits land on main in quick succession (e.g., batched dependabot updates).

Using cancel-in-progress: false to queue rather than cancel, ensuring every commit is considered by release-please and no changelog entries are silently dropped.

closes #200
closes #201
closes #203
closes #204

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>