### PR TITLE
build: update tree-sitter-java 0.21.0 → 0.23.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "tree-sitter": "0.21.1",
         "tree-sitter-c-sharp": "0.23.1",
         "tree-sitter-go": "0.21.2",
-        "tree-sitter-java": "0.21.0",
+        "tree-sitter-java": "^0.23.5",
         "tree-sitter-javascript": "0.21.4",
         "tree-sitter-python": "0.21.0",
         "tree-sitter-typescript": "0.21.2"
@@ -6355,20 +6355,20 @@
       }
     },
     "node_modules/tree-sitter-java": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.21.0.tgz",
-      "integrity": "sha512-CKJiTo1uc3SUsgEcaZgufGx8my6dzihy8JR/JsJH40Tj3uSe2/eFLk+0q+fpbosGAyY4YiXJtEoFB2O4bS2yOw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.23.5.tgz",
+      "integrity": "sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.0"
+        "tree-sitter": "^0.21.1"
       },
       "peerDependenciesMeta": {
-        "tree_sitter": {
+        "tree-sitter": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "tree-sitter": "0.21.1",
         "tree-sitter-c-sharp": "0.23.1",
         "tree-sitter-go": "0.21.2",
-        "tree-sitter-java": "^0.23.5",
+        "tree-sitter-java": "0.23.5",
         "tree-sitter-javascript": "0.21.4",
         "tree-sitter-python": "0.21.0",
         "tree-sitter-typescript": "0.21.2"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "tree-sitter": "0.21.1",
     "tree-sitter-c-sharp": "0.23.1",
     "tree-sitter-go": "0.21.2",
-    "tree-sitter-java": "^0.23.5",
+    "tree-sitter-java": "0.23.5",
     "tree-sitter-javascript": "0.21.4",
     "tree-sitter-python": "0.21.0",
     "tree-sitter-typescript": "0.21.2"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "tree-sitter": "0.21.1",
     "tree-sitter-c-sharp": "0.23.1",
     "tree-sitter-go": "0.21.2",
-    "tree-sitter-java": "0.21.0",
+    "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "0.21.4",
     "tree-sitter-python": "0.21.0",
     "tree-sitter-typescript": "0.21.2"


### PR DESCRIPTION
Minor version bump with improved Java grammar support. tree-sitter-c-sharp update was deferred as 0.23.5 requires tree-sitter@^0.25.0 (major bump) which is out of scope for a patch run.

Closes #306 