### PR TITLE
build: update eslint 10.3.0 → 10.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@vscode/test-electron": "2.5.2",
         "@vscode/vsce": "3.9.1",
         "c8": "11.0.0",
-        "eslint": "10.3.0",
+        "eslint": "^10.4.0",
         "mocha": "11.7.5",
         "typescript": "6.0.3"
       },
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2782,16 +2782,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@vscode/test-electron": "2.5.2",
         "@vscode/vsce": "3.9.1",
         "c8": "11.0.0",
-        "eslint": "^10.4.0",
+        "eslint": "10.4.0",
         "mocha": "11.7.5",
         "typescript": "6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@vscode/test-electron": "2.5.2",
     "@vscode/vsce": "3.9.1",
     "c8": "11.0.0",
-    "eslint": "^10.4.0",
+    "eslint": "10.4.0",
     "mocha": "11.7.5",
     "typescript": "6.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@vscode/test-electron": "2.5.2",
     "@vscode/vsce": "3.9.1",
     "c8": "11.0.0",
-    "eslint": "10.3.0",
+    "eslint": "^10.4.0",
     "mocha": "11.7.5",
     "typescript": "6.0.3"
   },


### PR DESCRIPTION
Minor ESLint update — all existing rules and configuration remain compatible.

closes #311 