### PR TITLE
ci: remove redundant compile step on non-Linux runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,8 @@ jobs:
             vscode-test-${{ runner.os }}-
       - run: xvfb-run -a npm run test:coverage
         if: runner.os == 'Linux'
-      # On non-Linux, compile and run tests directly to skip the redundant lint
-      # (lint is OS-agnostic and already runs on Linux via test:coverage)
-      - run: npm run compile
-        if: runner.os != 'Linux'
+      # On non-Linux, run unit tests directly (test:unit already compiles)
+      # and skip lint (OS-agnostic; already run on Linux via test:coverage).
       - run: npm run test:unit
         if: runner.os != 'Linux'
       - run: npm run test:vscode


### PR DESCRIPTION
test:unit already runs `npm run compile` internally before invoking mocha.
The standalone `npm run compile` step that preceded it on non-Linux runners
was therefore compiling TypeScript twice per CI run, wasting 2-3 seconds on
macOS and Windows.

Remove the redundant step. test:unit still compiles before running mocha, so
any TypeScript errors surface at the same point in the pipeline.
Closes #380

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
