### PR TITLE
build: upgrade tree-sitter-typescript 0.21.2 → 0.23.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "tree-sitter-javascript": "0.21.4",
         "tree-sitter-python": "0.21.0",
         "tree-sitter-rust": "0.21.0",
-        "tree-sitter-typescript": "0.21.2"
+        "tree-sitter-typescript": "0.23.2"
       },
       "devDependencies": {
         "@types/mocha": "10.0.10",
@@ -6400,20 +6400,40 @@
       "license": "MIT"
     },
     "node_modules/tree-sitter-typescript": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.21.2.tgz",
-      "integrity": "sha512-/RyNK41ZpkA8PuPZimR6pGLvNR1p0ibRUJwwQn4qAjyyLEIQD/BNlwS3NSxWtGsAWZe9gZ44VK1mWx2+eQVldg==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.1"
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.0"
       },
       "peerDependenciesMeta": {
-        "tree_sitter": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript/node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -134,6 +134,6 @@
     "tree-sitter-javascript": "0.21.4",
     "tree-sitter-python": "0.21.0",
     "tree-sitter-rust": "0.21.0",
-    "tree-sitter-typescript": "0.21.2"
+    "tree-sitter-typescript": "0.23.2"
   }
 }


### PR DESCRIPTION
The tree-sitter-typescript grammar at 0.23.2 is compatible with the
current tree-sitter@0.21.1 core (peerDependency: ^0.21.0).

Changes in 0.23.x grammar:
- Improved TypeScript 5.x support (const type parameters, variadic
  tuple labels, override accessors, etc.)
- Better handling of decorator positioning
- More accurate JSX / TSX parsing edge cases

The upgrade is a drop-in replacement: all 103 unit tests pass,
compile and lint are clean.

Note: a coordinated upgrade of the full tree-sitter ecosystem to 0.25.x
is the forward path to unlock tree-sitter-c-sharp@0.23.5,
tree-sitter-go@0.25.x, and others. However, tree-sitter-java@0.23.5 and
tree-sitter-rust@0.24.0 still peg to tree-sitter ^0.21.x and ^0.22.x
respectively, so the full upgrade must wait until all language parsers
align on a common tree-sitter version.

closes #390

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
