### PR TITLE
build: update `@types/node` 26.0.0→26.0.1 and eslint 10.5.0→10.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.10",
-        "@types/node": "26.0.0",
+        "@types/node": "26.0.1",
         "@types/vscode": "1.106.1",
         "@typescript-eslint/eslint-plugin": "8.62.0",
         "@typescript-eslint/parser": "8.62.0",
@@ -27,7 +27,7 @@
         "@vscode/test-electron": "3.0.0",
         "@vscode/vsce": "3.9.2",
         "c8": "11.0.0",
-        "eslint": "10.5.0",
+        "eslint": "10.6.0",
         "mocha": "11.7.6",
         "typescript": "6.0.3"
       },
@@ -898,9 +898,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2720,9 +2720,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.10",
-    "@types/node": "26.0.0",
+    "@types/node": "26.0.1",
     "@types/vscode": "1.106.1",
     "@typescript-eslint/eslint-plugin": "8.62.0",
     "@typescript-eslint/parser": "8.62.0",
@@ -122,7 +122,7 @@
     "@vscode/test-electron": "3.0.0",
     "@vscode/vsce": "3.9.2",
     "c8": "11.0.0",
-    "eslint": "10.5.0",
+    "eslint": "10.6.0",
     "mocha": "11.7.6",
     "typescript": "6.0.3"
   },


### PR DESCRIPTION
Patch and minor updates for dev tooling:
- @types/node: 26.0.0 → 26.0.1
- eslint: 10.5.0 → 10.6.0

npm run compile, lint, and test:unit all pass.

Closes #425

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
