### PR TITLE
build: update `@types/vscode` 1.106.1 → 1.125.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@types/mocha": "10.0.10",
         "@types/node": "26.0.1",
-        "@types/vscode": "1.106.1",
+        "@types/vscode": "1.125.0",
         "@typescript-eslint/eslint-plugin": "8.62.0",
         "@typescript-eslint/parser": "8.62.0",
         "@vscode/test-cli": "0.0.15",
@@ -922,9 +922,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.106.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.106.1.tgz",
-      "integrity": "sha512-R/HV8u2h8CAddSbX8cjpdd7B8/GnE4UjgjpuGuHcbp1xV6yh4OeqU4L1pKjlwujCrSFS0MOpwJAIs/NexMB1fQ==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   "devDependencies": {
     "@types/mocha": "10.0.10",
     "@types/node": "26.0.1",
-    "@types/vscode": "1.106.1",
+    "@types/vscode": "1.125.0",
     "@typescript-eslint/eslint-plugin": "8.62.0",
     "@typescript-eslint/parser": "8.62.0",
     "@vscode/test-cli": "0.0.15",


### PR DESCRIPTION
Brings VS Code API type definitions up to date (VS Code 1.125.0).
No new VS Code APIs are used — this is a pure type-definition bump
that unlocks stricter type checking and better IDE autocomplete
when working against newer VS Code APIs in future PRs.

Compilation, lint, and all 159 unit tests pass without changes.

Closes #428

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
