### PR TITLE
ci: gate all checks behind a single required job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,31 +2,21 @@ name: Continuous Integration
 permissions:
   contents: read
 
+# Deliberately not path-filtered. `CI Gate` is a required status check, and a required
+# check that never reports stays *pending* rather than failing - so a docs-only pull
+# request would be unmergeable without an admin bypass.
 on:
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - 'eslint.config.mjs'
-      - '.vscode-test.mjs'
-      - '.github/workflows/ci.yml'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - 'eslint.config.mjs'
-      - '.vscode-test.mjs'
-      - '.github/workflows/ci.yml'
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Keyed on the pull request rather than the ref, and only superseding in-flight runs
+  # for `pull_request`: cancelling on `push` would abandon CI for a commit already on main.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -39,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -69,3 +61,52 @@ jobs:
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  ci-gate:
+    name: CI Gate
+    # `always()` is load-bearing. Without it the job inherits the implicit `success()`
+    # condition and is reported as *skipped* when a dependency fails - and branch
+    # protection treats a skipped check as satisfied, letting through exactly the pull
+    # requests this job exists to stop.
+    if: always()
+    needs: [build]
+
+    permissions:
+      contents: read
+
+    # `ubuntu-slim` ships jq and bash, which is everything this job needs.
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+
+    steps:
+      - name: Check that every gated job succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          # Comma-separated jobs allowed to report `skipped`. Empty on purpose: nothing
+          # here is skipped by design, so an accidental `if:` cannot quietly stop gating
+          # a job.
+          ALLOWED_SKIPS: ""
+        run: |
+          {
+            echo "### CI Gate"
+            echo ""
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "$NEEDS_JSON" | jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failing=$(echo "$NEEDS_JSON" | jq -r --arg allowed "$ALLOWED_SKIPS" '
+            ($allowed | split(",") | map(select(length > 0))) as $ok
+            | to_entries[]
+            | select(.value.result != "success")
+            | select(.value.result != "skipped" or ([.key] - $ok | length) > 0)
+            | "\(.key): \(.value.result)"
+          ')
+
+          if [ -n "$failing" ]; then
+            echo "::error::One or more gated jobs did not succeed:"
+            echo "$failing"
+            exit 1
+          fi
+
+          echo "All gated jobs succeeded or were intentionally skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,11 @@ jobs:
           # a job.
           ALLOWED_SKIPS: ""
         run: |
+          # Fail closed explicitly rather than relying on the runner's default
+          # `bash -e`: a `shell:` override would otherwise let a jq error through
+          # as an empty `failing` and pass the gate.
+          set -euo pipefail
+
           {
             echo "### CI Gate"
             echo ""
@@ -96,7 +101,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           failing=$(echo "$NEEDS_JSON" | jq -r --arg allowed "$ALLOWED_SKIPS" '
-            ($allowed | split(",") | map(select(length > 0))) as $ok
+            ($allowed | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $ok
             | to_entries[]
             | select(.value.result != "success")
             | select(.value.result != "skipped" or ([.key] - $ok | length) > 0)


### PR DESCRIPTION
## Why

Branch protection on `main` requires three matrix contexts *by name*: `build (macos-latest)`, `build (ubuntu-latest)` and `build (windows-latest)`, plus `Validate PR title`. That couples the ruleset to the matrix definition — adding or removing an OS silently changes what is enforced until someone remembers to edit branch protection.

The bigger problem is the interaction with path filtering. `ci.yml` only triggered on `src/**`, the build config files and itself. A pull request touching only `README.md`, `samples/`, `resources/` or another workflow **never triggered CI**, so those three required contexts never reported. A required check that never reports stays *pending* rather than failing, and pending blocks merge indefinitely — which is why docs-only changes could only land via an admin bypass.

This adds a single required check, `CI Gate`, downstream of every other job. Once the ruleset requires `Validate PR title` + `CI Gate`, jobs can be added and removed later without anyone having to touch branch protection.

Ports the idea from [open-feature/dotnet-sdk-contrib#726](https://github.com/open-feature/dotnet-sdk-contrib/pull/726).

## What changed

Everything is in `.github/workflows/ci.yml`:

- **Dropped the `paths:` filters** from both `push` and `pull_request`. A gate is only meaningful if it always reports, and skipping CI wholesale was the source of the forced bypass. Docs-only PRs now run the matrix; the repo is public, so the minutes are free.
- **Added the `ci-gate` job** on `ubuntu-slim`, with `needs: [build]` and `if: always()`. It renders a `| Job | Result |` table into the step summary, then fails on any dependency that did not succeed.
- **Scoped `cancel-in-progress` to `pull_request`.** It previously applied to `push` on `main` too, so back-to-back merges cancelled CI for an already-merged commit. The concurrency group is now keyed on the PR number rather than the ref.
- **`persist-credentials: false`** on checkout — nothing runs authenticated git afterwards, so there is no reason to leave the job token in `.git/config`.
- **Added `workflow_dispatch`** for manual re-runs.

## Things worth calling out

- **`if: always()` is load-bearing.** Without it the gate inherits the implicit `success()` condition and is reported as *skipped* when a dependency fails — and branch protection treats a skipped check as satisfied. That would let through exactly the pull requests it is meant to stop. The predicate also fails on `cancelled` and on any skip that is not explicitly allow-listed.
- **`ALLOWED_SKIPS` is empty.** Nothing here is skipped by design, so an accidental `if:` cannot quietly stop gating a job. The mechanism is kept for future use.
- **The `build` job keeps its name deliberately.** Renaming it to `Build` would change the `build (<os>)` contexts, and those need to keep reporting until the ruleset is updated after this merges. Keeping them stable makes the transition a non-event — unlike the reference PR, protection does *not* have to be relaxed beforehand.
- **`ubuntu-slim` already ships `jq` (1.7) and `bash` (5.2)**, so the gate needs no install step. Verified against the [runner image manifest](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md).

## Differences from dotnet-sdk-contrib#726

- **No merge queue here**, so there is no `merge_group:` trigger, no queue-safe concurrency handling, and `validate_pr_title.yml` is left completely untouched. (It runs on `pull_request_target`, a different event, so it could never be a `needs:` dependency regardless — it stays a separate required check.)
- **No reusable workflows.** Those were only necessary there because gated jobs lived in a separate workflow file (`dotnet-format.yml`) and `needs:` cannot cross files. Everything here already lives in `ci.yml`, so splitting it would rename every check context for no benefit.

## Required after merging this

The ruleset still requires the three `build (*)` contexts. They keep reporting, so nothing is broken in the meantime, but the swap should happen once this lands:

```bash
gh api repos/askpt/code-metrics/rulesets/7860457 \
  | jq '{name, target, enforcement, bypass_actors, conditions,
         rules: (.rules | map(
           if .type == "required_status_checks"
           then .parameters.required_status_checks = [
                  {context: "CI Gate",           integration_id: 15368},
                  {context: "Validate PR title", integration_id: 15368}
                ]
           else . end))}' \
  | gh api -X PUT repos/askpt/code-metrics/rulesets/7860457 --input -
```

`integration_id: 15368` is GitHub Actions. Passing the existing rules array back through preserves everything else — linear history, required signatures, CodeQL, code quality, Copilot review, review-thread resolution and squash-only merges.

The 5 currently-open PRs will need a rebase afterwards to pick up the gate.

## Not gated

- `codecov/project` and `codecov/patch` are posted by the Codecov app rather than by a job, so they cannot be a `needs:` dependency. They are advisory today and stay that way.
- `release.yml` (push-to-main only), `copilot-setup-steps.yml` (self-scoped, not required), and the agentic `issue-triage` / `repo-assist` workflows (issues, discussions and comments — not PR checks) are all untouched.
- CodeQL, code quality and Copilot code review are ruleset *rule types*, not status checks, so the gate neither covers nor disturbs them.

## Validation

- `actionlint` — clean.
- `shellcheck` on the extracted gate script — clean.
- The gate script was exercised locally against synthetic `needs` payloads: all-green, single failure, `cancelled`, unexpected `skipped`, allow-listed `skipped`, a mixed multi-job payload, and an allow-list naming a job that isn't present. All eight produced the expected exit code and summary table.