### PR TITLE
docs: fix stale code-complexity repo name references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@
 **Target Runtime**: VS Code Extension Host (Node.js 22.x)  
 **Repository Size**: Small-medium (~20 source files)
 
-This repository contains a VS Code extension called "code-complexity" that calculates and displays Cognitive Complexity metrics based on SonarSource's specification. The extension analyzes C# and Go code files and provides CodeLens overlays showing complexity scores with color-coded indicators (green/yellow/red).
+This repository contains a VS Code extension called "code-metrics" that calculates and displays Cognitive Complexity metrics based on SonarSource's specification. The extension analyzes C# and Go code files and provides CodeLens overlays showing complexity scores with color-coded indicators (green/yellow/red).
 
 **Key Features**:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We welcome contributions to the Code Metrics VS Code extension! This document pr
 
 1. **Fork and Clone**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/code-complexity.git
+   git clone https://github.com/YOUR_USERNAME/code-metrics.git
    cd code-metrics
    ```
 


### PR DESCRIPTION
The repository was renamed from code-complexity to code-metrics, but
CONTRIBUTING.md's git clone example and .github/copilot-instructions.md's
project description still referenced the old name, which would give new
contributors an incorrect clone URL.

Closes #553

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
